### PR TITLE
hardening/29_mr_lib_api_version_method

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - [tidoop-mr-lib] [HARDENING] Add reference to tidoop-mr-lib-api in the usage section of the README (#41)
 - [tidoop-hadoop-ext] [HARDENING] Add an installation section in the README (#20)
 - [tidoop-mr-lib-api] [HARDENING] Set 12000 as default port and "cosmos" as the database name in the configuration (#45)
+- [tidoop-mr-lib-api] [HARDENING] Fix the GET version method in the README (#29)

--- a/tidoop-mr-lib-api/README.md
+++ b/tidoop-mr-lib-api/README.md
@@ -88,7 +88,7 @@ The Http server implemented by tidoop-mr-lib-api is run as (assuming your curren
     
 If everything goes well, you should be able to remotely ask (using a web browser or `curl` tool) for the version of the software:
 
-    $ curl -X GET "http://<host_running_the_api>:12000/version"
+    $ curl -X GET "http://<host_running_the_api>:12000/tidoop/v1/version"
     {version: 0.0.0}
     
 tidoop-mr-lib-api typically listens in the TCP/12000 port, but you can change if by editing `conf/tidoop-mr-lib-api.conf` as seen above.


### PR DESCRIPTION
- Fix issue #29 
- No unit tests nor e2e tests are required
- Assignee @gtorodelvalle 
