### PR TITLE
hardening/47_add_host_config

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - [tidoop-mr-lib] [HARDENING] Add reference to tidoop-mr-lib-api in the usage section of the README (#41)
 - [tidoop-hadoop-ext] [HARDENING] Add an installation section in the README (#20)
 - [tidoop-mr-lib-api] [HARDENING] Set 12000 as default port and "cosmos" as the database name in the configuration (#45)
+- [tidoop-mr-lib-api] [HARDENING] Add a host configuration parameter (#47)

--- a/tidoop-mr-lib-api/README.md
+++ b/tidoop-mr-lib-api/README.md
@@ -70,6 +70,7 @@ To be done.
 ##<a name="configuration"></a>Configuration
 tioop-mr-lib-api is configured through a JSON file (`conf/tidoop-mr-lib-api.json`). These are the available parameters:
 
+* **host**: FQDN or IP address of the host running the service. Do not use `localhost` unless you want only local clients may access the service.
 * **port**: TCP listening port for incomming API methods invocation. 12000 by default.
 * **tidoopMRLibPath**: Installation path for tidoop-mr-lib.
 * **mysql**:

--- a/tidoop-mr-lib-api/conf/tidoop-mr-lib-api.json
+++ b/tidoop-mr-lib-api/conf/tidoop-mr-lib-api.json
@@ -1,4 +1,5 @@
 {
+  "host": "localhost",
   "port": 12000,
   "tidoopMRLibPath": "path/to/tidoop-mr-lib",
   "mysql": {

--- a/tidoop-mr-lib-api/src/server.js
+++ b/tidoop-mr-lib-api/src/server.js
@@ -36,7 +36,7 @@ var serverUtils = require('./server_utils.js');
 var server = new Hapi.Server();
 
 server.connection({ 
-    host: 'localhost',
+    host: config.host,
     port: config.port
 });
 

--- a/tidoop-mr-lib-api/src/server.js
+++ b/tidoop-mr-lib-api/src/server.js
@@ -161,7 +161,7 @@ mysqlDriver.connect(function(error) {
                 return console.log("Some error occurred during the starting of the Hapi server. Details: " + error);
             } // if
 
-            console.log("tidoop-mr-lib-api running at http://localhost:" + config.port);
+            console.log("tidoop-mr-lib-api running at http://" + config.host + ":" + config.port);
         });
     } // if else
 });


### PR DESCRIPTION
- Implements issue #47 
- No unit tests still available.
- (unofficial) e2e tests passed:

```
$ /Users/frb/.nvm/v0.10.38/bin/npm start

> tidoop-mr-lib-api@0.0.0 start /Users/frb/devel/fiware/fiware-tidoop/tidoop-mr-lib-api
> node ./src/server.js

Connected to http://130.206.81.225:3306/cosmos_gui
tidoop-mr-lib-api running at http://192.168.1.37:12000
```
- Assignee @gtorodelvalle 
